### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ Timeline.css
 
 The best way to create your own Timeline, with just CSS!
 
-#Preview
+# Preview
 
 <img src="https://coderwall-assets-0.s3.amazonaws.com/uploads/picture/file/1749/Screenshot_from_2013-06-12_16_40_18.png" style='display:block;margin:auto' alt=""/>
 
-#License
-##MIT licensed
+# License
+## MIT licensed
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
